### PR TITLE
Bring in cosign sign and attest support and fix verify-enterprise-contract

### DIFF
--- a/resources/common.sh
+++ b/resources/common.sh
@@ -17,6 +17,10 @@ function exit_with_fail_result () {
     exit 1
 }
  
+timestamp() {
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
 DIR=$(pwd)
 export TASK_NAME=$(basename $0 .sh)
 export BASE_RESULTS=$DIR/results 

--- a/resources/cosign-sign-attest.sh
+++ b/resources/cosign-sign-attest.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# cosign-sign-attest
+source $SCRIPTDIR/common.sh
+
+base64d() {
+  base64 -d <<< "$1"
+}
+
+function full-image-ref() {
+  local url=$(cat $BASE_RESULTS/buildah-rhtap/IMAGE_URL)
+  local digest=$(cat $BASE_RESULTS/buildah-rhtap/IMAGE_DIGEST)
+  echo "$url@$digest"
+}
+
+# This is probably going to be quay.io, but let's not hard code it
+# here (even though it might be hard coded in a other places).
+function image-registry() {
+  local url=$(cat $BASE_RESULTS/buildah-rhtap/IMAGE_URL)
+  echo "${url/\/*/}"
+}
+
+# Cosign can use the same credentials as buildah
+function cosign-login() {
+  local image_registry="$(image-registry)"
+  cosign login -u "$QUAY_IO_CREDS_USR" -p "$QUAY_IO_CREDS_PSW" "$image_registry"
+}
+
+# A wrapper for running cosign used for both sign and attest.
+# Handles the password, the key, the rekor options, etc.
+function cosign-cmd() {
+  local cmd="$1" && shift
+  local opts=("$@")
+
+  # Do some special handling if the value of REKOR_HOST is "none". This makes
+  # it easier when testing these scripts without a real Rekor instance available.
+  # Note that we're expecting REKOR_HOST to start with "http://" or "https://" so
+  # it's actually a url not a host.
+  if [ -n "$REKOR_HOST" -a "$REKOR_HOST" != "none" ]; then
+    # A rekor host was specified, let's use it
+    REKOR_OPT="--rekor-url=$REKOR_HOST"
+  else
+    # If we don't set --rekor-url the default behavior would be to use the upstream
+    # public Rekor instance at https://rekor.sigstore.dev. Rather than use that, let's
+    # skip Rekor entirely, which means you need to use --insecure-ignore-tlog when
+    # verifying with cosign, or --skip-rekor when verifying with ec.
+    # (If you really want to use the upstream public Rekor then set your REKOR_HOST
+    # environment var to "https://rekor.sigstore.dev".)
+    REKOR_OPT="--tlog-upload=false"
+  fi
+
+  FULL_IMAGE_REF=$(full-image-ref)
+
+  # To consider: We could probably do without the base64 encoding if we had a
+  # dependable way to create Jenkins secret text credentials with multiple line
+  # breaks in them. If the COSIGN_PASSWORD and COSIGN_KEY vars were created
+  # directly from the credential value then this would look more tidy.
+  # (There are also numerous other ways to provide the secret key to cosign.)
+  COSIGN_PASSWORD=$(base64d "$COSIGN_SECRET_PASSWORD") \
+  COSIGN_KEY=$(base64d "$COSIGN_SECRET_KEY") \
+    cosign "$cmd" -y --key=env://COSIGN_KEY $REKOR_OPT "${opts[@]}" "$FULL_IMAGE_REF"
+}
+
+# The content of this is mostly placeholder for now, we'll add more to it later.
+# Useful references:
+# - https://slsa.dev/spec/v1.0/provenance
+# - http://localhost:8080/env-vars.html/
+#   (Replace localhost with your Jenkins instance)
+function create-att-predicate() {
+  yq -o=json -I=0 <<EOT
+buildDefinition:
+  buildType: "https://redhat.com/rhtap/slsa-build-types/jenkins-build/v1"
+  externalParameters: {}
+  internalParameters: {}
+  resolvedDependencies:
+    - uri: "git+${GIT_URL}"
+      digest:
+        gitCommit: "${GIT_COMMIT}"
+runDetails:
+  builder:
+    id: "${NODE_NAME}"
+    builderDependencies: {}
+    version:
+      # Not sure if this is the right place for these...
+      buildNumber: "${BUILD_NUMBER}"
+      jobName: "${JOB_NAME}"
+      executorNumber: "${EXECUTOR_NUMBER}"
+      jenkinsHome: "${JENKINS_HOME}"
+      buildUrl: "${BUILD_URL}"
+      jobUrl: "${JOB_URL}"
+  metadata:
+    invocationID: "${BUILD_TAG}"
+    startedOn: "$(cat $BASE_RESULTS/init/START_TIME)"
+    # Inaccurate, but not sure what else to do here
+    finishedOn: "$(timestamp)"
+  byproducts: {}
+EOT
+}
+
+# Sign the image using cosign.
+# Signing secret key and password should be base64 encoded in environment
+# vars COSIGN_SECRET_PASSWORD and COSIGN_SECRET_KEY.
+function sign() {
+  echo "Running $TASK_NAME:sign"
+  cosign-login
+  cosign-cmd sign
+}
+
+# Create provenance predicate and use it to cosign attest the image
+function attest() {
+  echo "Running $TASK_NAME:attest"
+  # Put the predicate file in the results also for debugging purposes
+  create-att-predicate > "$RESULTS/att-predicate.json"
+  # (Assume we did cosign login already)
+  cosign-cmd attest --predicate "$RESULTS/att-predicate.json" --type "https://slsa.dev/provenance/v1"
+}
+
+function show-rekor-url() {
+  echo "Running $TASK_NAME:show-rekor-url"
+  echo -n "Rekor URL: "
+  echo "${REKOR_HOST}" | tee "$RESULTS/REKOR_URL"
+}
+
+function show-public-key() {
+  echo "Running $TASK_NAME:show-public-key"
+  # Anyone wanting to verify the image needs the public key so let's provide
+  # it here so there's at least one way to access it
+  echo "Public key:"
+  base64d "$COSIGN_PUBLIC_KEY" | tee "$RESULTS/cosign.pub"
+}
+
+# Task Steps
+sign
+attest
+show-rekor-url
+show-public-key
+
+exit_with_success_result

--- a/resources/gather-deploy-images.sh
+++ b/resources/gather-deploy-images.sh
@@ -11,6 +11,7 @@ function get-images-per-env() {
 	set -euo pipefail
 	
 	IMAGE_PATH='.spec.template.spec.containers[0].image'
+	IMAGES_FILE=$HOMEDIR/all-images.txt
 	component_name=$(yq .metadata.name application.yaml)
 	
 	for env in development stage prod; do
@@ -26,9 +27,9 @@ function get-images-per-env() {
 	  fi
 	
 	  printf "%s\n" "$image"
-	done | sort -u > /tmp/all-images.txt
+	done | sort -u > "$IMAGES_FILE"
 	
-	if [ ! -s /tmp/all-images.txt ]; then
+	if [ ! -s "$IMAGES_FILE" ]; then
 	  echo "No images to verify"
 	  touch $RESULTS/IMAGES_TO_VERIFY
 	  exit 0
@@ -37,7 +38,7 @@ function get-images-per-env() {
 	# TODO: each component needs a {"source": {"git": {"url": "...", "revision": "..."}}}
 	#       will that be too large for Tekton results?
 	
-	jq --compact-output --raw-input --slurp < /tmp/all-images.txt '
+	jq --compact-output --raw-input --slurp < "$IMAGES_FILE" '
 	  # split input file
 	  split("\n") |
 	  # drop empty lines

--- a/resources/init.sh
+++ b/resources/init.sh
@@ -24,6 +24,8 @@ REQUIRED_BINARY+="python3 "
 # remember to leave a space when you add them to a prior ENV list
 REQUIRED_ENV="IMAGE_URL IMAGE "
 REQUIRED_ENV+="QUAY_IO_CREDS_USR QUAY_IO_CREDS_PSW "
+# Cosign signing
+REQUIRED_ENV+="COSIGN_SECRET_PASSWORD COSIGN_SECRET_KEY COSIGN_PUBLIC_KEY "
 # SCANS
 REQUIRED_ENV+="DISABLE_ACS "
 if [ "$DISABLE_ACS" != 'true' ]; then
@@ -48,6 +50,7 @@ fi
 function init() {
 	echo "Running $TASK_NAME:init"
 	echo "DEMO $TASK_NAME:init"
+	timestamp > $RESULTS/START_TIME
 	#!/bin/bash
 	echo "Build Initialize: $IMAGE_URL"
 	echo "Determine if Image Already Exists"

--- a/resources/verify-enterprise-contract.sh
+++ b/resources/verify-enterprise-contract.sh
@@ -1,22 +1,21 @@
 #!/bin/bash
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 # verify-enterprise-contract
 source $SCRIPTDIR/common.sh
 
-# Top level parameters 
-
 function version() {
 	echo "Running $TASK_NAME:version"
-	ec version  
+	ec version
 }
 
 function initialize-tuf() {
 	echo "Running $TASK_NAME:initialize-tuf"
 	set -euo pipefail
-	
-	if [[ -z "${TUF_MIRROR:-}" ]]; then
-	    echo 'TUF_MIRROR not set. Skipping TUF root initialization.'
-	else 
+
+	if [[ -z "${TUF_MIRROR:-}" || "${TUF_MIRROR:-}" = "none" ]]; then
+		echo 'TUF_MIRROR not set or set to "none". Skipping TUF root initialization.'
+	else
 		echo 'Initializing TUF root...'
 		cosign initialize --mirror "${TUF_MIRROR}" --root "${TUF_MIRROR}/root.json"
 		echo 'Done!'
@@ -25,57 +24,74 @@ function initialize-tuf() {
 
 function validate() {
 	echo "Running $TASK_NAME:validate"
-	
+
 	IMAGES=$(cat $BASE_RESULTS/gather-deploy-images/IMAGES_TO_VERIFY)
-	echo "Images to Verify "
-	cat $BASE_RESULTS/gather-deploy-images/IMAGES_TO_VERIFY | jq  
-	ec "$IMAGES" \
+	echo "Images to verify: "
+	echo "$IMAGES" | jq
+	echo -n "Policy used: "
+	echo "$POLICY_CONFIGURATION"
+	echo -n "Rekor URL: "
+	echo "$REKOR_HOST"
+
+	if [ -n "$REKOR_HOST" -a "$REKOR_HOST" != "none" -a "$IGNORE_REKOR" != "true" ]; then
+		REKOR_OPT="--rekor-url=$REKOR_HOST"
+	else
+		REKOR_OPT="--ignore-rekor"
+	fi
+
+	PUBLIC_KEY=$(base64 -d <<< "$COSIGN_PUBLIC_KEY")
+
+	ec validate image \
+          "--images" \
+          "$IMAGES" \
           "--policy" \
           "$POLICY_CONFIGURATION" \
           "--public-key" \
-          "$PUBLIC_KEY" \
-          "--rekor-url" \
-          "$REKOR_HOST" \
-          "--ignore-rekor=$IGNORE_REKOR" \
+          <(echo "$PUBLIC_KEY") \
+          "$REKOR_OPT" \
           "--info=$INFO" \
           "--strict=false" \
           "--show-successes" \
-          "--effective-time=$EFFECTIVE_TIME \
-          "--output" \ 
+          "--effective-time=$EFFECTIVE_TIME" \
+          "--output" \
           "yaml=$HOMEDIR/report.yaml" \
           "--output" \
           "appstudio=$RESULTS/TEST_OUTPUT" \
           "--output" \
-          "json=$HOMEDIR/report-json.json"
+          "json=$HOMEDIR/report-json.json" \
+          "--output" \
+          "text"
 }
 
 function report() {
 	echo "Running $TASK_NAME:report"
-	cat "$HOMEDIR/report.yaml" 
+	cat "$HOMEDIR/report.yaml"
+}
 
 function report-json() {
 	echo "Running $TASK_NAME:report-json"
-	cat  "$HOMEDIR/report-json.json" 
+	cat  "$HOMEDIR/report-json.json"
 }
 
 function summary() {
 	echo "Running $TASK_NAME:summary"
-	jq "." "$RESULTS/TEST_OUTPUT" 
+	jq "." "$RESULTS/TEST_OUTPUT"
 }
 
 function assert() {
 	echo "Running $TASK_NAME:assert"
-	jq --argjson strict "$STRICT" -e" \
-        ".result == \"SUCCESS\" or .result == \"WARNING\" or ($strict | not)\n" \
-          "$RESULTS/TEST_OUTPUT"
+	jq --argjson strict "$STRICT" -e \
+        ".result == \"SUCCESS\" or .result == \"WARNING\" or (\$strict | not)" \
+        "$RESULTS/TEST_OUTPUT"
 }
-  
-# Task Steps 
+
+# Task Steps
 version
 initialize-tuf
 validate
 report
 report-json
 summary
-assert 
+assert
+
 exit_with_success_result

--- a/vars/rhtap.groovy
+++ b/vars/rhtap.groovy
@@ -20,6 +20,9 @@ def init( ) {
 def buildah_rhtap( ) { 
     run_script ('buildah-rhtap.sh') 
 }   
+def cosign_sign_attest( ) {
+    run_script ('cosign-sign-attest.sh')
+}
 def acs_deploy_check( ) { 
     run_script ('acs-deploy-check.sh') 
 }


### PR DESCRIPTION
These changes come from the following PR:
https://github.com/jduimovich/tssc-jenkins/pull/2
See commit messages for more details on these changes.

Initial diff generated with hack/copy-to-tssc-templates in that repo, but I added cosign_sign_attest to the rhtap.grooy file by hand.

See also: https://github.com/redhat-appstudio/tssc-sample-templates/pull/63

Ref: [EC-740](https://issues.redhat.com/browse/EC-740)