### PR TITLE
Install the missing merge-sboms script

### DIFF
--- a/vars/rhtap.groovy
+++ b/vars/rhtap.groovy
@@ -18,6 +18,8 @@ def init( ) {
     run_script ('init.sh') 
 }   
 def buildah_rhtap( ) { 
+    // This is called from buildah-rhtap.sh
+    install_script ('merge-sboms.sh')
     run_script ('buildah-rhtap.sh') 
 }   
 def cosign_sign_attest( ) {


### PR DESCRIPTION
The script is called from the build-rhtap.sh so we need to make sure it gets copied in so it's available when it's called.

(I decided not to rename the file to merge-sboms.py based on the idea that there might some valid reason I'm not aware of why that wasn't done already.)

Ref: https://issues.redhat.com/browse/RHTAPBUGS-1277