### PR TITLE
Don't verify redhat-appstudio/dance-bootstrap-app

### DIFF
--- a/resources/gather-deploy-images.sh
+++ b/resources/gather-deploy-images.sh
@@ -24,6 +24,12 @@ function get-images-per-env() {
 	      # don't check images that didn't change between the current revision and the target branch
 	      continue
 	    fi
+
+	    # Workaround for RHTAPBUGS-1284
+	    if [[ "$image" =~ "quay.io/redhat-appstudio/dance-bootstrap-app" ]]; then
+	      # Don't check the dance-bootstrap-app image
+	      continue
+	    fi
 	  fi
 	
 	  printf "%s\n" "$image"


### PR DESCRIPTION
I'm not sure if this is a good solution, (or if this bug would actually be a real problem in production), but I'm proposing this change as a quick workaround RHTAPBUGS-1284 for to help get testing unblocked.

Ref: https://issues.redhat.com/browse/RHTAPBUGS-1284