### PR TITLE
Don't verify redhat-appstudio/dance-bootstrap-app

### DIFF
--- a/resources/gather-deploy-images.sh
+++ b/resources/gather-deploy-images.sh
@@ -25,6 +25,12 @@ function get-images-per-env() {
 	      continue
 	    fi
 	  fi
+
+	  # Workaround for RHTAPBUGS-1284
+	  if [[ "$image" =~ "quay.io/redhat-appstudio/dance-bootstrap-app" ]]; then
+	    # Don't check the dance-bootstrap-app image
+	    continue
+	  fi
 	
 	  printf "%s\n" "$image"
 	done | sort -u > "$IMAGES_FILE"


### PR DESCRIPTION
I'm not sure if this is a good solution, (or if this bug would actually be a real problem in production), but I'm proposing this change as a quick workaround RHTAPBUGS-1284 for to help get testing unblocked.

(This is an alternate version of #4 with the new test being done outside of the target branch if block.)

Ref: https://issues.redhat.com/browse/RHTAPBUGS-1284